### PR TITLE
Bad practise to change default shell

### DIFF
--- a/token-setup.mkd
+++ b/token-setup.mkd
@@ -25,14 +25,6 @@ Make sure that `/opt/homebrew/bin` (if using an ARM Mac) or `/usr/local/bin` (x8
 2. `$ brew install pinentry-mac`
 3. `$ brew install gnupg`
 
-This guide assumes that you are using Bash. Note that this is not the default shell on macOS Catalina and forward.
-
-You can install an up-to-date version of Bash using Homebrew:
-
-1. `$ brew install bash`
-2. `$ sudo bash -c "echo $(which bash) >> /etc/shells"`
-3. `$ chsh -s $(which bash)`
-
 ### Update gpg.conf
 Create a gpg.conf in `key_space` containing:
 ```
@@ -95,14 +87,6 @@ Make sure that `/opt/homebrew/bin` (if using an ARM Mac) or `/usr/local/bin` (x8
 1. `$ brew install ykman`
 2. `$ brew install pinentry-mac`
 3. `$ brew install gnupg`
-
-This guide assumes that you are using Bash. Note that this is not the default shell on macOS Catalina and forward.
-
-You can install an up-to-date version of Bash using Homebrew:
-
-1. `$ brew install bash`
-2. `$ sudo bash -c "echo $(which bash) >> /etc/shells"`
-3. `$ chsh -s $(which bash)`
 
 ### Create a more secure workspace
 1. `$ umask 077`
@@ -252,9 +236,9 @@ ssb>  rsa4096 2021-05-28 [A] [expires: 2022-05-28]
 
 `$ echo "pinentry-program $(which pinentry-mac)" >> ~/.gnupg/gpg-agent.conf`
 
-`$ echo "export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)" >> ~/.bash_profile`
+`$ echo "export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)" >> ~/.zshrc`
 
-`$ echo "gpgconf --launch gpg-agent" >> ~/.bash_profile`
+`$ echo "gpgconf --launch gpg-agent" >> ~/.zshrc`
 
 `$ gpg --export-ssh-key <ID> > ~/.ssh/id_rsa_yubikey.pub`
 


### PR DESCRIPTION
This guides is (almost always?) used in new freshly installed machines so there is no good reason to install a new shell and use is as default.

Power users of `bash` which acutally wants to change shell can adjust for them self.